### PR TITLE
fix: remove duplicate test run in CI workflow

### DIFF
--- a/.github/workflows/elixir.yml
+++ b/.github/workflows/elixir.yml
@@ -37,8 +37,6 @@ jobs:
       - name: Install dependencies
         run: mix deps.get
       - name: Run tests
-        run: mix test
-      - name: Run tests
         run: mix coveralls.json
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
Eliminate the redundant test execution step in the CI workflow.